### PR TITLE
Update source to make it compatible with Unreal 4.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@
 *.exe
 *.out
 *.app
+
+# Compiled folders
+Binaries/
+Intermediate/

--- a/Serial/Source/Serial/Private/src/impl/list_ports/list_ports_win.cc
+++ b/Serial/Source/Serial/Private/src/impl/list_ports/list_ports_win.cc
@@ -6,7 +6,6 @@
  * A copy of the licence can be obtained from:
  * http://opensource.org/licenses/MIT
  */
-#include "AllowWindowsPlatformTypes.h"
 #include "serial.h"
 #include <tchar.h>
 #include <windows.h>
@@ -148,7 +147,5 @@ serial::list_ports()
 
 	return devices_found;
 }
-
-#include "HideWindowsPlatformTypes.h"
 
 #endif // #if defined(_WIN32)

--- a/Serial/Source/Serial/Private/src/impl/win.cc
+++ b/Serial/Source/Serial/Private/src/impl/win.cc
@@ -4,7 +4,6 @@
 
 #include <sstream>
 
-#include "AllowWindowsPlatformTypes.h"
 #include "win.h"
 
 
@@ -638,7 +637,6 @@ Serial::SerialImpl::writeUnlock()
   }
 }
 
-#include "HideWindowsPlatformTypes.h"
 
 #endif // #if defined(_WIN32)
 


### PR DESCRIPTION
`#include "AllowWindowsPlatformTypes.h"` Was giving me problems when compiling with Unreal 4.13 on Windows 10, you might want to test it on your machine before accepting the PR.
